### PR TITLE
Show the stack for an RPN expression

### DIFF
--- a/src/components/RPNPresentation.scss
+++ b/src/components/RPNPresentation.scss
@@ -1,2 +1,25 @@
 .RPNPresentation {
+  .container {
+    display: flex;
+    align-content: end;
+    margin: 16px 0;
+    .boxes {
+      display: flex;
+      width: 100%;
+      flex-direction: column-reverse;
+      .box {
+        align-self: center;
+        border: 1px solid black;
+        box-sizing: border-box;
+        height: 64px;
+        width: 64px;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+      }
+      .box:not(:last-child) {
+        border-top: 0;
+      }
+    }
+  }
 }

--- a/src/components/RPNPresentation.tsx
+++ b/src/components/RPNPresentation.tsx
@@ -1,5 +1,6 @@
-import React from "react";
+import React, { CSSProperties } from "react";
 import reversePolishNotation, {
+  RPNElement,
   RPNExpression,
   RPNSteps,
 } from "@/lib/reversePolishNotation";
@@ -9,15 +10,36 @@ type Props = {
   rpnExpression: RPNExpression;
 };
 
+function findLongestStep(steps: RPNSteps): Array<RPNElement> {
+  return steps.reduce((previous, current) => {
+    if (current.length > previous.length) {
+      return current;
+    } else {
+      return previous;
+    }
+  }, steps[0]);
+}
+
 function RPNPresentation({ rpnExpression }: Props) {
-  let rpnSteps: RPNSteps = [];
-  rpnSteps = reversePolishNotation(rpnExpression);
+  const rpnSteps: RPNSteps = reversePolishNotation(rpnExpression);
+  const longest = rpnSteps.length === 0 ? [] : findLongestStep(rpnSteps);
+
+  const containerStyle: CSSProperties = {
+    height: `${longest.length * 64}px`,
+  };
+
   return (
     <div className="RPNPresentation">
-      {rpnSteps.map((step, i) => (
-        // eslint-disable-next-line react/no-array-index-key
-        <div key={i}>{step.join(" ")}</div>
-      ))}
+      <div className="container" style={containerStyle}>
+        <div className="boxes">
+          {longest.map((element, index) => (
+            // eslint-disable-next-line react/no-array-index-key
+            <div key={index} className="box">
+              {element}
+            </div>
+          ))}
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/components/RPNPresentation.tsx
+++ b/src/components/RPNPresentation.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties } from "react";
+import React, { CSSProperties, useState } from "react";
 import reversePolishNotation, {
   RPNElement,
   RPNExpression,
@@ -28,17 +28,38 @@ function RPNPresentation({ rpnExpression }: Props) {
     height: `${longest.length * 64}px`,
   };
 
+  const [currentStep, setCurrentStep] = useState(0);
+  const step = rpnSteps.length === 0 ? [] : rpnSteps[currentStep];
+
   return (
     <div className="RPNPresentation">
       <div className="container" style={containerStyle}>
         <div className="boxes">
-          {longest.map((element, index) => (
+          {step.map((element, index) => (
             // eslint-disable-next-line react/no-array-index-key
             <div key={index} className="box">
               {element}
             </div>
           ))}
         </div>
+      </div>
+      <div className="buttons">
+        <button
+          type="button"
+          onClick={() => {
+            setCurrentStep((x) => Math.max(0, x - 1));
+          }}
+        >
+          ←
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            setCurrentStep((x) => Math.min(x + 1, rpnSteps.length - 1));
+          }}
+        >
+          →
+        </button>
       </div>
     </div>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -46,7 +46,7 @@ h1 {
 
 button {
   border-radius: 8px;
-  border: 1px solid transparent;
+  border: 1px solid darkgray;
   padding: 0.6em 1.2em;
   font-size: 1em;
   font-weight: 500;


### PR DESCRIPTION
# Description
Here we implement the visualization of the stack. I added some rudimentary control buttons to be able to cycle through the steps. They can still be improved but that would be outside of the scope of this PR.

# Screenshot
![Mar-16-2023 15-00-34](https://user-images.githubusercontent.com/3190666/225739353-121b3e6a-894f-4b37-8c06-53064de518c2.gif)
