### PR TITLE
Extract Controls component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,7 +38,10 @@ function App() {
           {error.message}
         </p>
       ))}
-      <RPNPresentation rpnExpression={rpnExpression} />
+      <RPNPresentation
+        key={rpnExpression.toString()}
+        rpnExpression={rpnExpression}
+      />
     </div>
   );
 }

--- a/src/components/Controls.scss
+++ b/src/components/Controls.scss
@@ -1,0 +1,8 @@
+.buttons {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(5, 1fr);
+  span {
+    place-self: center;
+  }
+}

--- a/src/components/Controls.tsx
+++ b/src/components/Controls.tsx
@@ -1,11 +1,12 @@
 import React, { Dispatch, SetStateAction } from "react";
 
 type Props = {
+  step: number;
   setStep: Dispatch<SetStateAction<number>>;
   stepsLength: number;
 };
 
-function Controls({ setStep, stepsLength }: Props) {
+function Controls({ step, setStep, stepsLength }: Props) {
   const maxStep = Math.max(0, stepsLength - 1);
   return (
     <div className="buttons">
@@ -17,6 +18,9 @@ function Controls({ setStep, stepsLength }: Props) {
       >
         ←
       </button>
+      <span>
+        {step + 1}/{maxStep + 1}
+      </span>
       <button
         type="button"
         onClick={() => {

--- a/src/components/Controls.tsx
+++ b/src/components/Controls.tsx
@@ -1,0 +1,32 @@
+import React, { Dispatch, SetStateAction } from "react";
+
+type Props = {
+  setStep: Dispatch<SetStateAction<number>>;
+  stepsLength: number;
+};
+
+function Controls({ setStep, stepsLength }: Props) {
+  const maxStep = Math.max(0, stepsLength - 1);
+  return (
+    <div className="buttons">
+      <button
+        type="button"
+        onClick={() => {
+          setStep((x) => Math.max(0, x - 1));
+        }}
+      >
+        ←
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          setStep((x) => Math.min(x + 1, maxStep));
+        }}
+      >
+        →
+      </button>
+    </div>
+  );
+}
+
+export default Controls;

--- a/src/components/Controls.tsx
+++ b/src/components/Controls.tsx
@@ -8,26 +8,39 @@ type Props = {
 
 function Controls({ step, setStep, stepsLength }: Props) {
   const maxStep = Math.max(0, stepsLength - 1);
+
+  const previousStep = () => {
+    setStep((x) => Math.max(0, x - 1));
+  };
+  const nextStep = () => {
+    setStep((x) => Math.min(x + 1, maxStep));
+  };
   return (
     <div className="buttons">
       <button
         type="button"
         onClick={() => {
-          setStep((x) => Math.max(0, x - 1));
+          setStep(0);
         }}
       >
-        ←
+        ⏪
+      </button>
+      <button type="button" onClick={previousStep}>
+        ⬅️
       </button>
       <span>
         {step + 1}/{maxStep + 1}
       </span>
+      <button type="button" onClick={nextStep}>
+        ➡️
+      </button>
       <button
         type="button"
         onClick={() => {
-          setStep((x) => Math.min(x + 1, maxStep));
+          setStep(maxStep);
         }}
       >
-        →
+        ⏩
       </button>
     </div>
   );

--- a/src/components/Controls.tsx
+++ b/src/components/Controls.tsx
@@ -1,4 +1,5 @@
 import React, { Dispatch, SetStateAction } from "react";
+import "./Controls.scss";
 
 type Props = {
   step: number;

--- a/src/components/RPNPresentation.tsx
+++ b/src/components/RPNPresentation.tsx
@@ -5,6 +5,7 @@ import reversePolishNotation, {
   RPNSteps,
 } from "@/lib/reversePolishNotation";
 import "./RPNPresentation.scss";
+import Controls from "./Controls";
 
 type Props = {
   rpnExpression: RPNExpression;
@@ -43,24 +44,7 @@ function RPNPresentation({ rpnExpression }: Props) {
           ))}
         </div>
       </div>
-      <div className="buttons">
-        <button
-          type="button"
-          onClick={() => {
-            setCurrentStep((x) => Math.max(0, x - 1));
-          }}
-        >
-          ←
-        </button>
-        <button
-          type="button"
-          onClick={() => {
-            setCurrentStep((x) => Math.min(x + 1, rpnSteps.length - 1));
-          }}
-        >
-          →
-        </button>
-      </div>
+      <Controls setStep={setCurrentStep} stepsLength={rpnSteps.length} />
     </div>
   );
 }

--- a/src/components/RPNPresentation.tsx
+++ b/src/components/RPNPresentation.tsx
@@ -44,7 +44,11 @@ function RPNPresentation({ rpnExpression }: Props) {
           ))}
         </div>
       </div>
-      <Controls setStep={setCurrentStep} stepsLength={rpnSteps.length} />
+      <Controls
+        step={currentStep}
+        setStep={setCurrentStep}
+        stepsLength={rpnSteps.length}
+      />
     </div>
   );
 }


### PR DESCRIPTION
# Description
Addresses #5 . The control buttons were extracted to a separate component. This is also adding the first and last buttons as requested by the issue.
Additionally, we made use of the key prop to force a state reset when the expression changes so the step resets to 0.

# Screenshot
![rpn](https://user-images.githubusercontent.com/3190666/225993474-086df097-575d-4c78-bc01-69597e5b004b.gif)
