### PR TITLE
Handle errors without throwing

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,6 +11,7 @@
     "@typescript-eslint/naming-convention": ["off"],
     "arrow-body-style": ["off"],
     "no-else-return": ["off"],
-    "import/prefer-default-export": ["off"]
+    "import/prefer-default-export": ["off"],
+    "no-plusplus": ["off"]
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,14 @@ import RPNPresentation from "./components/RPNPresentation";
 const sanitize = (input: string): string =>
   input.replace(/ +/g, " ").replace(/[^0-9\-+/* ^]/g, "");
 
+// We only need to show 1 set of errors.
+// We are doing this instead of doing multiple conditioned early returns
+// inside the input change function for each set of errors.
+const handleErrors = (...args: Array<Error[]>) => {
+  const shownErrors = args.find((errors) => errors.length > 0);
+  return shownErrors || [];
+};
+
 function App() {
   const [rpnInput, setRpnInput] = useState("");
   const [rpnSteps, setRpnSteps] = useState<RPNSteps>([]);
@@ -30,20 +38,13 @@ function App() {
 
     setRpnSteps(_rpnSteps);
 
-    if (parseErrors.length > 0) {
-      setErrors(parseErrors);
-      return;
-    }
+    const shownErrors = handleErrors(
+      parseErrors,
+      validationErrors,
+      evaluationErrors
+    );
 
-    if (validationErrors.length > 0) {
-      setErrors(validationErrors);
-      return;
-    }
-
-    if (evaluationErrors.length > 0) {
-      setErrors(evaluationErrors);
-      return;
-    }
+    setErrors(shownErrors);
   };
 
   return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,9 @@
 import React, { ChangeEvent, useState } from "react";
 import "./App.css";
-import { RPNExpression, parseRPNExpression } from "@/lib/reversePolishNotation";
+import reversePolishNotation, {
+  RPNSteps,
+  parseRPNExpression,
+} from "@/lib/reversePolishNotation";
 import { rpnValidations } from "./lib/rpnValidations";
 import RPNPresentation from "./components/RPNPresentation";
 
@@ -9,22 +12,37 @@ const sanitize = (input: string): string =>
 
 function App() {
   const [rpnInput, setRpnInput] = useState("");
-  const [rpnExpression, setRpnExpression] = useState<RPNExpression>([]);
+  const [rpnSteps, setRpnSteps] = useState<RPNSteps>([]);
   const [errors, setErrors] = useState<Array<Error>>([]);
 
   const inputChange = (event: ChangeEvent<HTMLInputElement>) => {
     const input = sanitize(event.target.value);
     setRpnInput(input);
 
-    const _rpnExpression = parseRPNExpression(input.trim());
+    const { result: rpnExpression, errors: parseErrors } = parseRPNExpression(
+      input.trim()
+    );
 
-    const _errors = rpnValidations(_rpnExpression);
-    setErrors(_errors);
+    const validationErrors = rpnValidations(rpnExpression);
 
-    if (_errors.length === 0) {
-      setRpnExpression(_rpnExpression);
-    } else {
-      setRpnExpression([]);
+    const { result: _rpnSteps, errors: evaluationErrors } =
+      reversePolishNotation(rpnExpression);
+
+    setRpnSteps(_rpnSteps);
+
+    if (parseErrors.length > 0) {
+      setErrors(parseErrors);
+      return;
+    }
+
+    if (validationErrors.length > 0) {
+      setErrors(validationErrors);
+      return;
+    }
+
+    if (evaluationErrors.length > 0) {
+      setErrors(evaluationErrors);
+      return;
     }
   };
 
@@ -38,10 +56,7 @@ function App() {
           {error.message}
         </p>
       ))}
-      <RPNPresentation
-        key={rpnExpression.toString()}
-        rpnExpression={rpnExpression}
-      />
+      <RPNPresentation key={rpnInput} rpnSteps={rpnSteps} />
     </div>
   );
 }

--- a/src/components/RPNPresentation.tsx
+++ b/src/components/RPNPresentation.tsx
@@ -1,14 +1,10 @@
 import React, { CSSProperties, useState } from "react";
-import reversePolishNotation, {
-  RPNElement,
-  RPNExpression,
-  RPNSteps,
-} from "@/lib/reversePolishNotation";
+import { RPNElement, RPNSteps } from "@/lib/reversePolishNotation";
 import "./RPNPresentation.scss";
 import Controls from "./Controls";
 
 type Props = {
-  rpnExpression: RPNExpression;
+  rpnSteps: RPNSteps;
 };
 
 function findLongestStep(steps: RPNSteps): Array<RPNElement> {
@@ -21,8 +17,7 @@ function findLongestStep(steps: RPNSteps): Array<RPNElement> {
   }, steps[0]);
 }
 
-function RPNPresentation({ rpnExpression }: Props) {
-  const rpnSteps: RPNSteps = reversePolishNotation(rpnExpression);
+function RPNPresentation({ rpnSteps }: Props) {
   const longest = rpnSteps.length === 0 ? [] : findLongestStep(rpnSteps);
 
   const containerStyle: CSSProperties = {

--- a/src/lib/reversePolishNotation.ts
+++ b/src/lib/reversePolishNotation.ts
@@ -18,13 +18,13 @@ const operations: Record<Operator, Operation> = {
 };
 
 const reversePolishNotation = (input: RPNExpression): Errorable<RPNSteps> => {
-  const rpnSteps: RPNSteps = [];
+  const result: RPNSteps = [];
   const stack: number[] = [];
   const errors: Array<Error> = [];
   for (let i = 0; i < input.length; i++) {
     const element = input[i];
     if (isOperator(element)) {
-      rpnSteps.push([...stack, element]);
+      result.push([...stack, element]);
       const b = stack.pop();
       const a = stack.pop();
       if (a === undefined || b === undefined) {
@@ -40,9 +40,9 @@ const reversePolishNotation = (input: RPNExpression): Errorable<RPNSteps> => {
     } else {
       stack.push(element);
     }
-    rpnSteps.push([...stack]);
+    result.push([...stack]);
   }
-  return { result: rpnSteps, errors };
+  return { result, errors };
 };
 
 export const parseRPNExpression = (input: string): Errorable<RPNExpression> => {

--- a/src/lib/reversePolishNotation.ts
+++ b/src/lib/reversePolishNotation.ts
@@ -3,9 +3,10 @@ type Operation = (a: number, b: number) => number;
 export type RPNElement = number | Operator;
 export type RPNExpression = Array<RPNElement>;
 export type RPNSteps = Array<Array<RPNElement>>;
+export type Errorable<T> = { result: T; errors: Array<Error> };
 
 export const isOperator = (element: RPNElement): element is Operator => {
-  return (element as Operator).length !== undefined;
+  return (element as Operator).length === 1;
 };
 
 const operations: Record<Operator, Operation> = {
@@ -16,38 +17,52 @@ const operations: Record<Operator, Operation> = {
   "^": (a, b) => a ** b,
 };
 
-const reversePolishNotation = (input: RPNExpression): RPNSteps => {
-  const result: RPNSteps = [];
+const reversePolishNotation = (input: RPNExpression): Errorable<RPNSteps> => {
+  const rpnSteps: RPNSteps = [];
   const stack: number[] = [];
-  input.forEach((element, i) => {
+  const errors: Array<Error> = [];
+  for (let i = 0; i < input.length; i++) {
+    const element = input[i];
     if (isOperator(element)) {
-      result.push([...stack, element]);
+      rpnSteps.push([...stack, element]);
       const b = stack.pop();
       const a = stack.pop();
       if (a === undefined || b === undefined) {
-        throw new Error(
-          `Insufficient operands for the "${element}" operator at index ${i}`
+        errors.push(
+          new Error(
+            `Insufficient operands for the "${element}" operator at index ${i}`
+          )
         );
+        break;
       }
       const c = operations[element](a, b);
       stack.push(c);
     } else {
       stack.push(element);
     }
-    result.push([...stack]);
-  });
-  return result;
+    rpnSteps.push([...stack]);
+  }
+  return { result: rpnSteps, errors };
 };
 
-export const parseRPNExpression = (input: string): RPNExpression => {
-  return input.split(" ").map((element) => {
+export const parseRPNExpression = (input: string): Errorable<RPNExpression> => {
+  const result: RPNExpression = [];
+  const errors: Array<Error> = [];
+  const elements = input.split(" ");
+  for (let i = 0; i < elements.length; i++) {
+    const element = elements[i];
     const number = parseFloat(element);
     if (Number.isNaN(number)) {
-      return element as Operator;
+      if (element.length > 1) {
+        errors.push(new Error(`Invalid operator "${element}" at index ${i}`));
+        break;
+      }
+      result.push(element as Operator);
     } else {
-      return number;
+      result.push(number);
     }
-  });
+  }
+  return { result, errors };
 };
 
 export default reversePolishNotation;

--- a/src/lib/rpnValidations.ts
+++ b/src/lib/rpnValidations.ts
@@ -14,7 +14,7 @@ const validationFunctions: Array<validationError> = [
       const numbers = input.filter((x) => !isOperator(x));
       return numbers.length === operators.length + 1;
     },
-    Error("There should be 1 operator more than numbers"),
+    Error("There should be 1 number more than operators"),
   ],
 ];
 

--- a/src/tests/reversePolishNotation.test.ts
+++ b/src/tests/reversePolishNotation.test.ts
@@ -8,13 +8,13 @@ import reversePolishNotation, {
 describe("Reverse Polish Notation", () => {
   it("handles simple expressions", () => {
     const input: RPNExpression = [2, 2, "+"];
-    const output = reversePolishNotation(input);
+    const { result: output } = reversePolishNotation(input);
     const expected = [[2], [2, 2], [2, 2, "+"], [4]];
     expect(output).toEqual(expected);
   });
   it("handles complex expressions", () => {
     const input: RPNExpression = [2, 5, "*", 6, "+", 3, 2, "^", 1, "-", "/"];
-    const output = reversePolishNotation(input);
+    const { result: output } = reversePolishNotation(input);
     const expected = [
       [2],
       [2, 5],
@@ -37,8 +37,10 @@ describe("Reverse Polish Notation", () => {
   });
   it("throws when short on operands", () => {
     const input: RPNExpression = [2, 2, "+", "*"];
-    expect(() => {
-      reversePolishNotation(input);
-    }).toThrowError(`Insufficient operands for the "*" operator at index 3`);
+    const { errors } = reversePolishNotation(input);
+    const error = errors[0];
+    expect(error.message).to.equal(
+      `Insufficient operands for the "*" operator at index 3`
+    );
   });
 });


### PR DESCRIPTION
## Description
We had a little problem with the way we were handling errors. Throwing mid evaluation was preventing us from displaying the half-evaluated without resorting to some ugly parameter mutation.
Errors are now returned as part of the return value of the parsing and evaluation functions. This allows us to handle all them together nicely.

Quick implementation detail:
We have errors coming from 3 possible steps: Parsing, Validation and Evaluation.
If there is an error on one step, then the next errors would/could be false negatives so we only want to show the first type of errors to provide only the helpful/relevant error messages.

## Screenshot

![Apr-23-2023 22-14-59](https://user-images.githubusercontent.com/3190666/233892299-4a82a02c-b0e8-48d3-bd5b-4f1aca71edb4.gif)
